### PR TITLE
OOB earn paid from app wallet

### DIFF
--- a/scripts/src/internal/app.ts
+++ b/scripts/src/internal/app.ts
@@ -8,7 +8,6 @@ const config = getConfig();
 const logger = initLogger(...config.loggers!);
 
 import { createRoutes } from "./routes";
-import { initPaymentCallbacks } from "./services";
 import { init as initModels } from "../models/index";
 import { init as initCustomMiddleware, notFoundHandler, generalErrorHandler } from "./middleware";
 import { init as initRemoteConfig } from "../public/routes/config";
@@ -40,6 +39,4 @@ export async function init() {
 	// initializing db and models
 	const msg = await initModels();
 	logger.info("init db", { msg });
-	const res = await initPaymentCallbacks(logger);
-	logger.info("init payment result", { res });
 }

--- a/scripts/src/internal/services.ts
+++ b/scripts/src/internal/services.ts
@@ -189,15 +189,3 @@ export async function paymentFailed(payment: FailedPayment, logger: LoggerInstan
 	await setFailedOrder(order, BlockchainError(payment.reason));
 	logger.info(`failed order with payment <${payment.id}>`);
 }
-
-/**
- * register to get callbacks for incoming payments for all the active offers
- */
-export async function initPaymentCallbacks(logger: LoggerInstance): Promise<Watcher> {
-	const offers = await Offer.find<Offer>({ type: "spend" }); // get all active spend offers
-	// create a list of unique addresses
-	const addresses = removeDuplicates(offers.map(offer => offer.blockchainData.recipient_address!));
-
-	logger.info("setting payment watching addresses", { addresses });
-	return await addWatcherEndpoint(addresses, "None");
-}


### PR DESCRIPTION
* Main purpose:
 Make OOB earn offers to be paid from app wallet instead of Kin root wallet 
* Technical description:
 - OOB spend not available for dev program - keep it like before (paid from client to root wallet)
 - instead of adding all offer spend addresses  to watcher at init - add watcher just in case there's a spend offer at createOrder() (practically there will be none in production)
* Dilemmas you faced with?
N/A
* Tests
N/A
* Documentation (Source/readme.md)
N/A