### PR TITLE
getOrderHistory not filtering opened orders

### DIFF
--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -38,9 +38,9 @@ function updateQueryWithFilter(query: SelectQueryBuilder<any>, name: string, val
 	}
 
 	if (value.startsWith("!")) {
-		query.andWhere(`${name} != :value`, { value: value.substring(1) });
+		query.andWhere(`${name} != :${name}`, { [name]: value.substring(1) });
 	} else {
-		query.andWhere(`${name} = :value`, { value });
+		query.andWhere(`${name} = :${name}`, { [name]: value });
 	}
 }
 
@@ -156,8 +156,10 @@ export class Order extends CreationDateModel {
 
 	public static getAll<T extends Order>(this: OrderStatic<T> | Function, filters: GetOrderFilters, limit?: number): Promise<T[]> {
 		const query = (this as OrderStatic<T>).createQueryBuilder()
-			.where("user_id = :userId", { userId: filters.userId }).
-			orWhere("recipient_id = :userId", { userId: filters.userId })
+			.where(new Brackets(qb => {
+				qb.where("user_id = :userId", { userId: filters.userId })
+					.orWhere("recipient_id = :userId", { userId: filters.userId });
+			}))
 			.orderBy("current_status_date", "DESC")
 			.addOrderBy("id", "DESC");
 


### PR DESCRIPTION
* Main purpose:
Fixing https://github.com/kinecosystem/kin-devplatform-marketplace-server/issues/10
* Technical description:
`Order.getAll` didn't filter opened order.
`Orders.getOrderHistory` uses `Order.getAll` (the only method that uses it), the filter didn't work, opened orders was returned and then an exception was raised (OpenedOrdersOnly)
  - fix getAll where filtering
  - fix a potential problem where using multiple filters (status and  origin for instance), the second filter will override the first (due to updateQueryWithFilter uses the same 'value' object key)
* Dilemmas you faced with?
N/A
* Tests
manually
* Documentation (Source/readme.md)
N/A