### PR TITLE
fix orders error field serialization to DB

### DIFF
--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -121,7 +121,7 @@ export class Order extends CreationDateModel {
 
 	public static async updateUncompletedOrders(): Promise<void> {
 		const now = moment().format("YYYY-MM-DD HH:mm:ss.SSS");
-		const errorMessage = TransactionTimeout().toString();
+		const errorMessage = TransactionTimeout().toJson();
 		await Order.createQueryBuilder()
 			.update("orders")
 			.set({ status: "failed", error: errorMessage })


### PR DESCRIPTION
* Main purpose:
Fix crash in client due to invalid json in orders error field 
* Technical description:
Happens in the scheduled clean operation, when updating in completed orders, error toString() will cause the json to have escape chars in DB, which is not valid json and crashes the client
* Dilemmas you faced with?
n/a
* Tests
n/a
* Documentation (Source/readme.md)
n/a