### PR TITLE
add update wallet address request after restoring an account

### DIFF
--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -44,6 +44,7 @@ const CODES = {
 		InvalidExternalOrderJwt: 4,
 		InvalidJwtSignature: 5,
 		JwtKidMissing: 6,
+		InvalidWalletAddress: 7,
 	},
 	TransactionFailed: {
 		WrongSender: 1,
@@ -233,4 +234,8 @@ export function BlockchainError(message?: string) {
 
 export function TransactionTimeout() {
 	return TransactionFailed(CODES.TransactionFailed.TransactionTimeout, "transaction_timeout");
+}
+
+export function InvalidWalletAddress(address: string) {
+	return BadRequestError(CODES.BadRequest.InvalidWalletAddress, `Invalid (not 56 characters) wallet address: ${ address }`);
 }

--- a/scripts/src/metrics.ts
+++ b/scripts/src/metrics.ts
@@ -45,6 +45,10 @@ export function reportServerError(method: string, path: string) {
 	statsd.increment("server_error", 1, undefined, { method, path });
 }
 
+export function walletAddressUpdate() {
+	statsd.increment("wallet_address_update_succeeded", 1);
+}
+
 export function orderFailed(order: Order, relatedUser?: User) {
 	function safeString(str: string): string {
 		return str.replace(/\W/g, " ");

--- a/scripts/src/public/routes/index.ts
+++ b/scripts/src/public/routes/index.ts
@@ -4,7 +4,7 @@ import * as db from "../../models/users";
 import { TOSMissingOrOldToken } from "../../errors";
 import { authenticate } from "../auth";
 import { getOffers } from "./offers";
-import { signInUser, activateUser } from "./users";
+import { signInUser, activateUser, updateUser } from "./users";
 import {
 	getOrder,
 	cancelOrder,
@@ -111,6 +111,7 @@ export function createRoutes(app: express.Express, pathPrefix?: string) {
 		Router()
 			.post("/", signInUser)
 			.authenticated() // no TOS scope
+			.patch("/", updateUser)
 			.post("/me/activate", activateUser));
 
 	app.get("/status", statusHandler);


### PR DESCRIPTION
* Main purpose:
 Backup and restore - update wallet address after restoring an account
* Technical description:
Add new authorized `PATCH` request to `/users`, with a new request containing only wallet address.
* Dilemmas you faced with?
N/A
* Tests
N/A
* Documentation (Source/readme.md)
N/A