### PR TITLE
DP-139 - cap reached error

### DIFF
--- a/scripts/src/models/orders.ts
+++ b/scripts/src/models/orders.ts
@@ -87,12 +87,13 @@ export class Order extends CreationDateModel {
 		return query.getCount();
 	}
 
-	public static countToday(userId: string, type: OfferType): Promise<number> {
+	public static countToday(userId: string, type: OfferType, origin: OrderOrigin): Promise<number> {
 		const midnight = new Date((new Date()).setUTCHours(0, 0, 0, 0));
 		const query = Order.createQueryBuilder()
 			.where("user_id = :userId", { userId })
 			.andWhere("type = :type", { type })
 			.andWhere("current_status_date > :midnight", { midnight })
+			.andWhere("origin = :origin", { origin })
 			.andWhere(new Brackets(qb => {
 				qb.where("status = :completed", { completed: "completed" })
 					.orWhere(

--- a/scripts/src/public/routes/users.ts
+++ b/scripts/src/public/routes/users.ts
@@ -100,10 +100,10 @@ export const activateUser = async function(req: Request, res: Response) {
 	res.status(200).send(authToken);
 } as any as RequestHandler;
 
-export const remainingDailyOffers = async function(userId: string): Promise<number> {
+export const remainingDailyMarketplaceOffers = async function(userId: string): Promise<number> {
 	const max_daily_earn_offers = getConfig().max_daily_earn_offers;
 	if (max_daily_earn_offers !== null) {
-		return max_daily_earn_offers - await dbOrders.Order.countToday(userId, "earn");
+		return max_daily_earn_offers - await dbOrders.Order.countToday(userId, "earn", "marketplace");
 	}
 	return 0;
 };

--- a/scripts/src/public/services/offers.ts
+++ b/scripts/src/public/services/offers.ts
@@ -9,7 +9,7 @@ import * as offerContents from "./offer_contents";
 import { Application } from "../../models/applications";
 import { ContentType, OfferType } from "../../models/offers";
 import { getConfig } from "../config";
-import { remainingDailyOffers } from "../routes/users";
+import { remainingDailyMarketplaceOffers } from "../routes/users";
 import * as orderDb from "../../models/orders";
 
 export interface PollAnswer {
@@ -123,6 +123,6 @@ export async function getOffers(userId: string, appId: string, filters: ModelFil
 }
 
 async function filterDailyCap(offers: Offer[], userId: string) {
-	offers = offers.slice(0, Math.max(0, await remainingDailyOffers(userId)));
+	offers = offers.slice(0, Math.max(0, await remainingDailyMarketplaceOffers(userId)));
 	return offers;
 }

--- a/scripts/src/public/services/orders.ts
+++ b/scripts/src/public/services/orders.ts
@@ -34,7 +34,7 @@ import { ExternalEarnOrderJWT, ExternalSpendOrderJWT, ExternalPayToUserOrderJwt 
 import {
 	create as createEarnTransactionBroadcastToBlockchainSubmitted
 } from "../../analytics/events/earn_transaction_broadcast_to_blockchain_submitted";
-import { remainingDailyOffers } from "../routes/users";
+import { remainingDailyMarketplaceOffers } from "../routes/users";
 
 export interface OrderList {
 	orders: Order[];
@@ -96,7 +96,7 @@ export async function changeOrder(orderId: string, change: Partial<Order>, logge
 }
 
 async function createOrder(offer: offerDb.Offer, user: User) {
-	if (await remainingDailyOffers(user.id) === 0) {
+	if (await remainingDailyMarketplaceOffers(user.id) === 0) {
 		return undefined;
 	}
 	const { senderAddress, recipientAddress } = await extractMarketplaceOrderWalletAddresses(user, offer);


### PR DESCRIPTION
* Main purpose:
Fix an issue when native earns where counted for user daily cap, this can prevent the user from getting offers when he already did 1 earn, and can also lead to "cap reach" error when trying to do native earn in marketplace while native earn already performed today.
* Technical description:
fix 'countToday' method to count only marketplace earn orders and not all user earn orders
* Dilemmas you faced with?
n/a
* Tests
n/a
* Documentation (Source/readme.md)