### PR TITLE
fix whitespace error, travis to just check build is passed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,18 @@ node_js:
   - "8"
 
 before_script:
-  - make build db # db - for make test
-  - make generate-funding-address
-  - make create-jwt-keys
-  - make up-dev # clear-redis # up-dev - for test-system-docker
+  # - make build db # db - for make test
+  # - make generate-funding-address
+  # - make create-jwt-keys
+  # - make up-dev # clear-redis # up-dev - for test-system-docker
 
 script:
-  - make test
-  - make test-system-docker
+  - make build
+  # - make test
+  # - make test-system-docker
 
 after_failure:
-  - make logs
+  # - make logs
 
 after_script:
-  - make down
+  # - make down

--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -46,7 +46,7 @@ const CODES = {
 		InvalidExternalOrderJwt: 4,
 		InvalidJwtSignature: 5,
 		JwtKidMissing: 6,
-		InvalidWalletAddress: 7,		
+		InvalidWalletAddress: 7,
 		MissingJwt: 8,
 		MaxWalletsExceeded: 9,
 	},


### PR DESCRIPTION
 - Configure Travis to run on each build - currently just `make build` to prevent tslint errors.
 - Fix tslint error.