### PR TITLE
Allow killswitch via api

### DIFF
--- a/config/internal.default.json
+++ b/config/internal.default.json
@@ -18,8 +18,10 @@
 		"logging": false
 	},
 	"payment_service": "http://localhost:5000",
+        "payment_service_v3": "http://localhost:5001",
 	"internal_service": "http://localhost:3001",
 	"jwt_keys_dir": "jwt",
 	"sign_in_types": ["jwt", "whitelist"],
-	"bi_service": "https://kin-bi.appspot.com/eco_"
+	"bi_service": "https://kin-bi.appspot.com/eco_",
+        "killswitch_via_api": "false"
 }

--- a/config/public.default.json
+++ b/config/public.default.json
@@ -24,11 +24,13 @@
 		"port": 8125
 	},
 	"payment_service": "http://localhost:5000",
+        "payment_service_v3": "http://localhost:5001",
 	"internal_service": "http://localhost:3001",
 	"webview": "https://some-url.com",
 	"ecosystem_service": "http://localhost:3000",
 	"environment_name": "local",
 	"bi_service": "https://kin-bi.appspot.com/eco_",
 	"sign_in_types": ["jwt", "whitelist"],
-	"max_daily_earn_offers": 4
+	"max_daily_earn_offers": 4,
+        "killswitch_via_api": "false"
 }

--- a/scripts/src/config.ts
+++ b/scripts/src/config.ts
@@ -22,6 +22,7 @@ export interface Config {
 	commit?: string;
 	timestamp?: string;
 	bi_service: string;
+	killswitch_via_api: string;
 }
 
 let config: Config;
@@ -47,6 +48,7 @@ export function init(filePath: string) {
 	config.commit = process.env.BUILD_COMMIT || config.commit;
 	config.timestamp = process.env.BUILD_TIMESTAMP || config.timestamp;
 	config.redis = process.env.APP_REDIS || config.redis;
+	config.killswitch_via_api = process.env.KILLSWITCH_VIA_API || config.killswitch_via_api;
 }
 
 export function getConfig<T extends Config>(): T {

--- a/scripts/src/models/offers.ts
+++ b/scripts/src/models/offers.ts
@@ -3,6 +3,7 @@ import { Column, Entity, Index, PrimaryColumn } from "typeorm";
 import { CreationDateModel, Model, register as Register, initializer as Initializer } from "./index";
 import { generateId, IdPrefix } from "../utils";
 import { OrderMeta, Order } from "./orders";
+import { type } from "os";
 
 export type BlockchainData = {
 	transaction_id?: string;
@@ -12,6 +13,7 @@ export type BlockchainData = {
 };
 
 export type BlockchainVersion = "2" | "3";
+export const BlockchainVersionValues = ["2", "3"] as BlockchainVersion[];
 
 export type OfferMeta = {
 	title: string;

--- a/scripts/src/public/routes/config.ts
+++ b/scripts/src/public/routes/config.ts
@@ -63,8 +63,8 @@ export type SetAppBlockchainVersionRequest = Request & {
 export const setAppBlockchainVersion = async function(req: SetAppBlockchainVersionRequest, res: Response) {
 	if (CONFIG.killswitch_via_api === "true") {
 		const app_id = req.params.app_id;
-		const data = await setAppBlockchainVersionService(app_id, req.body.blockchain_version);
-		res.status(200).send(data);
+		await setAppBlockchainVersionService(app_id, req.body.blockchain_version);
+		res.status(200).send();
 	} else {
 		res.status(403).send();
 	}

--- a/scripts/src/public/routes/config.ts
+++ b/scripts/src/public/routes/config.ts
@@ -61,7 +61,7 @@ export type SetAppBlockchainVersionRequest = Request & {
 };
 
 export const setAppBlockchainVersion = async function(req: SetAppBlockchainVersionRequest, res: Response) {
-	if (CONFIG.killswitch_via_api !== "true") {
+	if (CONFIG.killswitch_via_api === "true") {
 		const app_id = req.params.app_id;
 		const data = await setAppBlockchainVersionService(app_id, req.body.blockchain_version);
 		res.status(200).send(data);

--- a/scripts/src/public/routes/config.ts
+++ b/scripts/src/public/routes/config.ts
@@ -4,7 +4,9 @@ import { NextFunction, Request, RequestHandler, Response } from "express";
 import { BlockchainConfig, getBlockchainConfig } from "../services/payment";
 import { getDefaultLogger } from "../../logging";
 import { getJwtKeys } from "../services/internal_service";
-import { getAppBlockchainVersion as getAppBlockchainVersionService } from "../services/applications";
+import { getAppBlockchainVersion as getAppBlockchainVersionService,
+	setAppBlockchainVersion as setAppBlockchainVersionService } from "../services/applications";
+import { BlockchainVersion } from "../../models/offers";
 
 const CONFIG = getConfig();
 let JWT_KEYS: KeyMap;
@@ -47,4 +49,23 @@ export const getAppBlockchainVersion = async function(req: GetAppBlockchainVersi
 	const app_id = req.params.app_id;
 	const data = await getAppBlockchainVersionService(app_id);
 	res.status(200).send(data);
+} as any as RequestHandler;
+
+export type SetAppBlockchainVersionRequest = Request & {
+	params: {
+		app_id: string;
+	};
+	body: {
+		blockchain_version: BlockchainVersion;
+	}
+};
+
+export const setAppBlockchainVersion = async function(req: SetAppBlockchainVersionRequest, res: Response) {
+	if (CONFIG.killswitch_via_api !== "true") {
+		const app_id = req.params.app_id;
+		const data = await setAppBlockchainVersionService(app_id, req.body.blockchain_version);
+		res.status(200).send(data);
+	} else {
+		res.status(403).send();
+	}
 } as any as RequestHandler;

--- a/scripts/src/public/routes/config.ts
+++ b/scripts/src/public/routes/config.ts
@@ -6,7 +6,8 @@ import { getDefaultLogger } from "../../logging";
 import { getJwtKeys } from "../services/internal_service";
 import { getAppBlockchainVersion as getAppBlockchainVersionService,
 	setAppBlockchainVersion as setAppBlockchainVersionService } from "../services/applications";
-import { BlockchainVersion } from "../../models/offers";
+import { BlockchainVersion, BlockchainVersionValues } from "../../models/offers";
+import { config } from "bluebird";
 
 const CONFIG = getConfig();
 let JWT_KEYS: KeyMap;
@@ -62,9 +63,13 @@ export type SetAppBlockchainVersionRequest = Request & {
 
 export const setAppBlockchainVersion = async function(req: SetAppBlockchainVersionRequest, res: Response) {
 	if (CONFIG.killswitch_via_api === "true") {
-		const app_id = req.params.app_id;
-		await setAppBlockchainVersionService(app_id, req.body.blockchain_version);
-		res.status(200).send();
+		if (BlockchainVersionValues.indexOf(req.body.blockchain_version) > 0) {
+			const app_id = req.params.app_id;
+			await setAppBlockchainVersionService(app_id, req.body.blockchain_version);
+			res.status(200).send();
+		} else {
+			res.status(401).send();
+		}
 	} else {
 		res.status(403).send();
 	}

--- a/scripts/src/public/routes/index.ts
+++ b/scripts/src/public/routes/index.ts
@@ -15,7 +15,7 @@ import {
 	createExternalOrder,
 	whitelistTransaction
 } from "./orders";
-import { getConfigHandler, getAppBlockchainVersion } from "./config";
+import { getConfigHandler, getAppBlockchainVersion, setAppBlockchainVersion } from "./config";
 import { statusHandler } from "../middleware";
 
 export type Context = {
@@ -87,7 +87,8 @@ export function createRoutes(app: express.Express, pathPrefix?: string) {
 	app.use(createPath("config", pathPrefix),
 		Router()
 			.get("/", getConfigHandler)
-			.get("/blockchain/:app_id", getAppBlockchainVersion));
+			.get("/blockchain/:app_id", getAppBlockchainVersion)
+			.post("/blockchain/:app_id", setAppBlockchainVersion));
 
 	app.use(createPath("offers", pathPrefix),
 		Router()

--- a/scripts/src/public/services/applications.ts
+++ b/scripts/src/public/services/applications.ts
@@ -49,3 +49,13 @@ export async function getAppBlockchainVersion(app_id: string): Promise<Blockchai
 	}
 	return app.config.blockchain_version;
 }
+
+export async function setAppBlockchainVersion(app_id: string, blockchain_version: BlockchainVersion): Promise<void> {
+	const app = await Application.findOneById(app_id);
+	if (!app) {
+		throw NoSuchApp(app_id);
+	}
+
+	app.config.blockchain_version = blockchain_version;
+	app.save();
+}


### PR DESCRIPTION
For testing, we allow this API so that developers can dynamically set their "blockchain_version" via HTTP request. This will be turned off in prod
