### PR TITLE
fix bug when updating blockchain version deleted apps' offers

### DIFF
--- a/scripts/src/public/services/applications.ts
+++ b/scripts/src/public/services/applications.ts
@@ -57,5 +57,9 @@ export async function setAppBlockchainVersion(app_id: string, blockchain_version
 	}
 
 	app.config.blockchain_version = blockchain_version;
-	app.save();
+	await Application.createQueryBuilder()
+		.update("applications")
+		.set({ config : app.config })
+		.where("id = :id", { id : app_id })
+		.execute();
 }


### PR DESCRIPTION
#### Main purpose:
 fix bug when updating blockchain version deleted apps' offers
#### Technical description:
perform an update instead off `app.save()`, probably cause a problem because of typeorm created table of `applications_offers_offers`