### PR TITLE
DP-333 - block updating wallet not created in the same app

### DIFF
--- a/scripts/src/errors.ts
+++ b/scripts/src/errors.ts
@@ -51,6 +51,7 @@ const CODES = {
 		InvalidWalletAddress: 7,
 		MissingJwt: 8,
 		MaxWalletsExceeded: 9,
+		WalletWasNotCreatedInThisApp: 10,
 	},
 	TransactionFailed: {
 		WrongSender: 1,
@@ -258,4 +259,8 @@ export function TransactionTimeout() {
 
 export function InvalidWalletAddress(address: string) {
 	return BadRequestError(CODES.BadRequest.InvalidWalletAddress, `Invalid (not 56 characters) wallet address: ${ address }`);
+}
+
+export function WalletWasNotCreatedInThisApp(address: string, appId: string) {
+	return BadRequestError(CODES.BadRequest.WalletWasNotCreatedInThisApp, `Wallet wasn't created in this app. app id: ${ appId }, Wallet address: ${ address }`);
 }

--- a/scripts/src/models/wallets.ts
+++ b/scripts/src/models/wallets.ts
@@ -1,0 +1,27 @@
+import { BaseEntity, Column, Entity, PrimaryColumn } from "typeorm";
+import { register as Register } from "./index";
+
+@Entity({ name: "wallets" })
+@Register
+export class Wallet extends BaseEntity {
+
+	public static async doesExist(address: string, appId: string): Promise<boolean> {
+		const query = Wallet.createQueryBuilder()
+			.where("wallet_address = :address", { address })
+			.andWhere("app_id = :appId", { appId });
+		return query.getCount().then( count => count > 0);
+	}
+
+	public static add(address: string, appId: string): Promise<Wallet> {
+		const wallet = Wallet.create();
+		wallet.appId = appId;
+		wallet.walletAddress = address;
+		return wallet.save();
+	}
+
+	@PrimaryColumn({ name: "wallet_address" })
+	public walletAddress!: string;
+
+	@Column({ name: "app_id" })
+	public appId!: string;
+}

--- a/scripts/src/public/services/users.ts
+++ b/scripts/src/public/services/users.ts
@@ -9,6 +9,7 @@ import * as payment from "./payment";
 import { pick } from "../../utils";
 import * as metrics from "../../metrics";
 import { Application } from "../../models/applications";
+import { Wallet } from "../../models/wallets";
 
 export type AuthToken = {
 	token: string;
@@ -48,6 +49,7 @@ export async function getOrCreateUserCredentials(
 			existingUser.walletCount += 1;
 			existingUser.walletAddress = walletAddress;
 			await existingUser.save();
+			await Wallet.add(walletAddress, appId);
 			await payment.createWallet(app.config.blockchain_version, existingUser.walletAddress, existingUser.appId, existingUser.id, logger);
 			metrics.userRegister(false, true, appId);
 		} else {
@@ -62,6 +64,7 @@ export async function getOrCreateUserCredentials(
 			logger.info("creating a new user", { appId, appUserId });
 			user = User.new({ appUserId, appId, walletAddress });
 			await user.save();
+			await Wallet.add(walletAddress, appId);
 			logger.info(`creating stellar wallet for new user ${user.id}: ${user.walletAddress}`);
 			await payment.createWallet(app.config.blockchain_version, user.walletAddress, user.appId, user.id, logger);
 			metrics.userRegister(true, true, appId);


### PR DESCRIPTION
introduce a new table that will save created wallet addresses along with app id,
use this table to make sure with restore only wallets that alreadt exists

